### PR TITLE
show help if no arguments given

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -303,11 +303,14 @@ namespace argparse {
          *
          * Returns a reference to the Entry, which will collapse into the requested type in `Entry::operator T()`
          */
-        Entry &arg(const std::string &help) {
-            std::shared_ptr<Entry> entry = std::make_shared<Entry>(Entry::ARG, "arg_" + std::to_string(_arg_idx++), help);
+        Entry &arg(const std::string& name, const std::string &help) {
+            std::shared_ptr<Entry> entry = std::make_shared<Entry>(Entry::ARG, name, help);
             arg_entries.emplace_back(entry);
             all_entries.emplace_back(entry);
             return *entry;
+        }
+        Entry &arg(const std::string &help) {
+            return arg("arg_" + std::to_string(_arg_idx++), help);
         }
 
         /* Add a Key-Worded argument that takes a variable.

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -372,6 +372,11 @@ namespace argparse {
          * Upon error, it will print the error and exit immediately.
          */
         void parse(int argc, const char* const *argv, const bool &raise_on_error) {
+            if (argc == 1) { //if there are no arguments, assume the user doesn't know the options.
+                help();
+                exit(0);
+            }
+			
             program_name = argv[0];
             params = std::vector<std::string>(argv + 1, argv + argc);
 


### PR DESCRIPTION
If no arguments are given to a program that expects arguments, the current behaviour is to print an error associated with the first argument.

With this change, if no arguments are given, then assume the user doesn't know. Show help and exit. 

Won't work if all arguments are optional, but I don't know if that is a real use-case.