### PR TITLE
Bugfix/Escape CSI sequences correctly

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -66,7 +66,7 @@ namespace argparse {
 #ifdef _WIN32
         return input_str; // no bold for windows
 #else
-        return "\e[1m" + input_str + "\e[0m";
+        return "\\e[1m" + input_str + "\\e[0m";
 #endif
     }
 


### PR DESCRIPTION
I could not use the library on my Linux machine until I escaped the CSI sequences correctly: 
`\e` -> `\\e`

This PR should fix it for any unixoid system.
