### PR TITLE
Bugfix/Ambiguous name on Linux

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -62,7 +62,7 @@ namespace argparse {
     template <typename, typename = void> struct has_ostream_operator : std::false_type {};
     template <typename T> struct has_ostream_operator<T, decltype(void(std::declval<std::ostream&>() << std::declval<const T&>()))> : std::true_type {};
 
-    std::string bold(const std::string& input_str) {
+    inline std::string bold(const std::string& input_str) {
 #ifdef _WIN32
         return input_str; // no bold for windows
 #else


### PR DESCRIPTION
I had a linking error when using this library on my Linux system with GCC. 
I figured out making the function inline would fix this problem.

If the `inline` keyword triggers errors on Windows (should be tested probably), we could also make a platform dependent function declaration.