### PR TITLE
Added support for named positional arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,35 +1,37 @@
 # Argparse; Modern Argument Parser for C++17
-A lightweight header-only library for parsing command line arguments in an elegant manner. Argparse allows you to define variables as a one-liner without redefining their type or names while representing all the program arguments in a struct that can be easily passed to functions. 
+A lightweight header-only library for parsing command line arguments in an elegant manner. Argparse allows you to define variables as a one-liner without redefining their type or names while representing all the program arguments in a struct that can be easily passed to functions.
 
 ## Usage
 ```c++
 #include "argparse/argparse.hpp"
 
 struct MyArgs : public argparse::Args {
-    std::string &src_path = arg("a positional string argument");
-    int &k                = kwarg("k", "A keyworded integer value");
-    float &alpha          = kwarg("a,alpha", "An optional float value").set_default(0.5f);
-    bool &verbose         = flag("v,verbose", "A flag to toggle verbose");
+    std::string &anonymous = arg("an anonymous positional string argument");
+    std::string &src_path  = arg("src_path", "a positional string argument");
+    int &k                 = kwarg("k", "A keyworded integer value");
+    float &alpha           = kwarg("a,alpha", "An optional float value").set_default(0.5f);
+    bool &verbose          = flag("v,verbose", "A flag to toggle verbose");
 };
 
 
 int main(int argc, char* argv[]) {
-    MyArgs args = argparse::parse<MyArgs>(argc, argv);
+    auto args = argparse::parse<MyArgs>(argc, argv);
 
     if (args.verbose)
-        args.print();       // prints all variables 
+        args.print();      // prints all variables
 
     return 0;
 }
 ```
-Example output when setting the `verbose` flag in the example above, it will print the capturing arguments with the `args.print()` function: 
+Example output when setting the `verbose` flag in the example above, it will print the capturing arguments with the `args.print()` function:
 ```
-$ ./argparse_test source -k 4 --verbose
-    arg_0(a posit...) : source
+$ ./argparse_test hello source -k 4 --verbose
+    arg_0(an anon...) : hello
+ src_path(a posit...) : source
                    -k : 4
            -a,--alpha : 0.5
          -v,--verbose : true
-               --help : false
+            -?,--help : false
 ```
 
 # Input
@@ -37,7 +39,8 @@ Argparse distinguishes 3 different types of arguments:
 
 | Type | Function                                                                                                                 |
 | --- |:-------------------------------------------------------------------------------------------------------------------------|
-| `arg(help)`    | positional arguments                                                                                                     |
+| `arg(help)`    | anonymous positional arguments                                                                                                     |
+| `arg(key,help)`    | named positional arguments                                                                                                     |
 | `kwarg(key,help,implicit)`  | keyworded-arguments that require a key and a value, e.g. `--variable 0.5`.                                               |
 | `flag(key,help)`   | a boolean argument that is by default `false`, but can be set to `true` by defining it on the commandline (e.g. `--verbose`) |
 
@@ -84,7 +87,7 @@ numbers = 3,4,5
 ```
 
 # Vectors and multiple arguments
-Argparse supports `std::vector`. There are 2 ways in which the vector can be read from the commandline, either a vector can be parsed from a comma-separated string, or by setting the `multi_argument()` flag to aggregate multiple program arguments into the vector, e.g. when using the `./*` in bash to list all the files in a directory.  
+Argparse supports `std::vector`. There are 2 ways in which the vector can be read from the commandline, either a vector can be parsed from a comma-separated string, or by setting the `multi_argument()` flag to aggregate multiple program arguments into the vector, e.g. when using the `./*` in bash to list all the files in a directory.
 ```c++
 std::vector<int> &numbers           = kwarg("n,numbers", "An int vector");
 std::vector<std::string> &tags      = kwarg("t,tags", "A word vector");
@@ -92,7 +95,7 @@ std::vector<std::string> &files     = kwarg("files", "multiple arguments").multi
 ```
 Example usage:
 ```bash
-$ argparse_test --numbers 3,4,5,6                
+$ argparse_test --numbers 3,4,5,6
 $ argparse_test --numbers=3,4,5,6
 $ argparse_test --tags hello
 $ argparse_test --tags="1st tag,2nd tag"   # if the strings contain spaces
@@ -109,11 +112,11 @@ And the following input:
 ```bash
 $ argparse_test a b b b c
 ```
-Argparse will assign the non-multiple arguments first, such that `A=a`, `C=c` and `B=b,b,b` 
+Argparse will assign the non-multiple arguments first, such that `A=a`, `C=c` and `B=b,b,b`
 
 
 # Pointers and Optionals
-In situations where setting a default value is not sufficient, Argparse supports `std::optional`, and (smart)pointers, these can be used in situations where you'd like to distinguish whether an argument was set by the user. When declaring a raw pointer or a `std::shared_ptr`, the default value for these are automatically set to `nullptr` (or `std::nullopt` for `std::optional`). 
+In situations where setting a default value is not sufficient, Argparse supports `std::optional`, and (smart)pointers, these can be used in situations where you'd like to distinguish whether an argument was set by the user. When declaring a raw pointer or a `std::shared_ptr`, the default value for these are automatically set to `nullptr` (or `std::nullopt` for `std::optional`).
 ```c++
 std::shared_ptr<float> &alpha   = kwarg("a,alpha", "An optional smart-pointer float parameter");
 std::optional<float> &beta      = kwarg("b,beta", "An optional float parameter with std::optional return");
@@ -167,7 +170,7 @@ struct CommitArgs : public argparse::Args {
     bool &all                       = flag("a,all", "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told git about are not affected.");
     std::string &message            = kwarg("m,message", "Use the given <msg> as the commit message.");
 
-    // This will be executed via `args.run_subcommands()` if the user calls the `commit` subcommand 
+    // This will be executed via `args.run_subcommands()` if the user calls the `commit` subcommand
     int run() override {
         std::cout << "running commit with the with the following message: " << this->message << std::endl;
         return 0;
@@ -249,7 +252,7 @@ int main(int argc, char* argv[]) {
 }
 ```
 # Examples and help flag
-The `--help` is automatically added in ArgParse. Consider the following example usage when executing `argparse_test` (int `examples/argparse_example.cpp`): 
+The `--help` is automatically added in ArgParse. Consider the following example usage when executing `argparse_test` (int `examples/argparse_example.cpp`):
 ```
 $ ./argparse_example --help
 Welcome to Argparse
@@ -269,14 +272,14 @@ Options:
 ```
 You may notice the `Welcome to Argparse` message, this message was created by overwriting the `welcome` function (see `examples/argparse_example.cpp`)
 
-In case it fails to parse the input string, it will display an error and exit. E.g. here we'll set `k` to be `notanumber`: 
+In case it fails to parse the input string, it will display an error and exit. E.g. here we'll set `k` to be `notanumber`:
 ```
 $ ./argparse_test src dst -k notanumber
 Invalid argument, could not convert "notanumber" for -k (An implicit int parameter)
 ```
 
 # Installing
-Since it is a header-only library, you can simply copy the `include/argparse.hpp` file into your own project. 
+Since it is a header-only library, you can simply copy the `include/argparse.hpp` file into your own project.
 
 Alternatively, you can build&install it using the following commands:
 ```
@@ -291,9 +294,9 @@ It can be included in your cmake project as follows:
 find_package(argparse REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC argparse::argparse)
-``` 
+```
 
 # FAQ
  - **Why references?**
-   
-    This is a good question. In order to support implicit parameters, multiple parameters and invariance to the order of input, Argparse needs to know all the possible input arguments before assigning them. And since the goal of this library is to define a variable only once, I needed a way to modify the contents of the returned value after it has seen all the arguments. Returning by reference makes this possible. In the future, when guaranteed copy-elision is implemented for primitive types, the reference can be removed.  
+
+    This is a good question. In order to support implicit parameters, multiple parameters and invariance to the order of input, Argparse needs to know all the possible input arguments before assigning them. And since the goal of this library is to define a variable only once, I needed a way to modify the contents of the returned value after it has seen all the arguments. Returning by reference makes this possible. In the future, when guaranteed copy-elision is implemented for primitive types, the reference can be removed.

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -5,11 +5,13 @@
 #include "argparse/argparse.hpp"
 
 struct MyArgs : public argparse::Args {
-    std::string &src_path           = arg("a positional string argument");
-    int &k                          = kwarg("k", "A keyworded integer value");
-    float &alpha                    = kwarg("a,alpha", "An optional float value").set_default(0.5f);
-    bool &verbose                   = flag("v,verbose", "A flag to toggle verbose");
+    std::string &anonymous = arg("an anonymous positional string argument");
+    std::string &src_path  = arg("src_path", "a positional string argument");
+    int &k                 = kwarg("k", "A keyworded integer value");
+    float &alpha           = kwarg("a,alpha", "An optional float value").set_default(0.5f);
+    bool &verbose          = flag("v,verbose", "A flag to toggle verbose");
 };
+
 
 int main(int argc, char* argv[]) {
     auto args = argparse::parse<MyArgs>(argc, argv);

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -328,7 +328,19 @@ namespace argparse {
          * Returns a reference to the Entry, which will collapse into the requested type in `Entry::operator T()`
          */
         Entry &arg(const std::string &help) {
-            std::shared_ptr<Entry> entry = std::make_shared<Entry>(Entry::ARG, "arg_" + std::to_string(_arg_idx++), help);
+            return arg("arg_" + std::to_string(_arg_idx), help);
+        }
+
+        /* Add a *named* positional argument, the order in which it is defined equals the order in which they are being read.
+         * key : The name of the argument, otherwise arg_<position> will be used
+         * help : Description of the variable
+         *
+         * Returns a reference to the Entry, which will collapse into the requested type in `Entry::operator T()`
+         */
+        Entry &arg(const std::string& key, const std::string &help) {
+            std::shared_ptr<Entry> entry = std::make_shared<Entry>(Entry::ARG, key, help);
+            // Increasing _arg_idx, so that arg2 will be arg_2, irregardless of whether it is preceded by other positional arguments
+            _arg_idx++;
             arg_entries.emplace_back(entry);
             all_entries.emplace_back(entry);
             return *entry;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -110,6 +110,7 @@ void TEST_ENUM() {
 void TEST_ALL() {
     struct Args : public argparse::Args {
         std::string& src_path           = arg("Source path");
+        std::string& named_arg          = arg("named_arg", "Named argument");
         std::string& dst_path           = arg("Destination path").set_default("world");// default value set to "world"
         std::vector<std::string>& others= arg("Others").multi_argument().set_default<std::vector<std::string>>({});// default value set to empty vector
         int& k                          = kwarg("k", "A required parameter (short only)", "3");   // Implicit value set to 3
@@ -127,9 +128,10 @@ void TEST_ALL() {
     };
 
     {
-        Args args = test_args<Args>("argparse_test source_path destination -k=5 --alpha=1 --beta 3.3 --gamma --numbers=1,2,3,4,5 --numbers2 6,7,8 --files f1 f2 f3 --custom hello_custom --optional 1 --verbose");
+        Args args = test_args<Args>("argparse_test source_path named_arg_input destination -k=5 --alpha=1 --beta 3.3 --gamma --numbers=1,2,3,4,5 --numbers2 6,7,8 --files f1 f2 f3 --custom hello_custom --optional 1 --verbose");
 
         assert(args.src_path == "source_path");
+        assert(args.named_arg == "named_arg_input");
         assert(args.dst_path == "destination");
         assert(args.k == 5);
         assert(args.alpha != nullptr && std::abs(*args.alpha - 1) < 0.0001);
@@ -146,9 +148,10 @@ void TEST_ALL() {
     }
 
     {
-        Args args = test_args<Args>("argparse_test source_path -k --files --custom hello_custom --optional 1 --verbose");
+        Args args = test_args<Args>("argparse_test source_path named_arg_input -k --files --custom hello_custom --optional 1 --verbose");
 
         assert(args.src_path == "source_path");
+        assert(args.named_arg == "named_arg_input");
         assert(args.dst_path == "world");
         assert(args.k == 3);
         assert(args.alpha == nullptr);


### PR DESCRIPTION
Hi Morris,

I really like your argparse project and happily started using it in my own project. But there was something that I wanted to add. I think it is much more elegant to give names to positional arguments than using arg0, arg1, etc (like in Python's argparse or p-ranav's argparse. I hope you are open to adding it. This PR contains the changes to make that happen.

Now the help will look like this (so src_path instead of arg_1)

`$ ./hello_world --help
Usage: hello_world arg_0 src_path  [options...]
            arg_0 : an anonymous positional string argument [required]
         src_path : a positional string argument [required]
`

Also the argument name will be used when printing the argument values.

Some remarks on my solution:
- I decided to go for a function overloading-based solution. Another (backwards compatible) way would be to add an optional argument to the existing function, but that would be inconsistent with the arguments order that you have for kwargs and flag (key first, help second).
- I also updated some tests and the documentation, but the extent to which it could be updated is of course subjective. Let me know if you want more updates (or make them yourself).
- The Readme.md had quite some trailing whitespace (most of the changes in there are just that). I hope you are fine with removing that as well (my IDE automatically removed it).

Are you also open for the following changes (not in this PR):
- Omitting "Options" from the help if there are no options
- Updating the help for subcommands from `Usage: subcommand arg0 ...` to `Usage: program subcommand arg0 ...`
Probably I would refactor a little bit to make it easy to test the generated help

Thanks in advance,
Stef