### PR TITLE
Validate that no extra positional arguments are provided

### DIFF
--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -560,6 +560,16 @@ namespace argparse {
                 if (arg_i < arguments_flat.size())
                     arg_entries[arg_i]->_convert(arguments_flat[arg_i]);
             }
+
+            if (arg_i == arg_entries.size() && arg_i < arguments_flat.size()) {
+                if (raise_on_error) {
+                    throw std::runtime_error("Too many positional values");
+                } else {
+                    std::cerr << "Too many positional values" << std::endl;
+                    exit(-1);
+                }
+            }
+
             size_t arg_j = 1;
             for (size_t j_end = arg_entries.size() - arg_i; arg_j <= j_end; arg_j++) { // iterate from back to front, to ensure non-multi-arguments in the front and back are given preference
                 size_t flat_idx = arguments_flat.size() - arg_j;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -204,7 +204,7 @@ void TEST_THROW() {
     }
 
     {
-        std::string command = "argparse_test source_path source_path";
+        std::string command = "argparse_test source_path";
         const auto &[argc, argv] = get_argc_argv(command);
         try {
             auto args = argparse::parse<Args>(argc, argv, true);
@@ -212,6 +212,17 @@ void TEST_THROW() {
             assert(std::string(e.what()) ==  "Argument missing: -a,--alpha (required alpha value)");
         }
     }
+
+    {
+        std::string command = "argparse_test source_path source_path";
+        const auto &[argc, argv] = get_argc_argv(command);
+        try {
+            auto args = argparse::parse<Args>(argc, argv, true);
+        } catch (const std::runtime_error &e) {
+            assert(std::string(e.what()) ==  "Too many positional values");
+        }
+    }
+
 }
 
 void TEST_SUBCOMMANDS() {
@@ -331,7 +342,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Magic Enum not installed in this system, therefore native enum support disabled" << std::endl;
 #endif
 
-    TEST_SUBCOMMANDS();    
+    TEST_SUBCOMMANDS();
     TEST_SHORT_GROUP();
     TEST_EQUALS();
     TEST_EMPTY_MULTI();


### PR DESCRIPTION
I propose to add validation that there is no extra positional arguments.  Such check was helpful for me to detect why behavior is the same despite I run different command.  